### PR TITLE
use Promise.all when array literals are yielded

### DIFF
--- a/codemod.js
+++ b/codemod.js
@@ -3,7 +3,18 @@ export default function transformer (file, api) {
 
   const yieldToAwait = p => {
     const node = p.node
-    const arg = node.argument
+    let arg = node.argument
+    // use Promise.all for array literals, e.g.
+    // await Promise.all([promise1, promise2, ...])
+    if (arg.type === 'ArrayExpression') {
+      arg = j.callExpression(
+        j.memberExpression(
+          j.identifier('Promise'),
+          j.identifier('all')
+        ),
+        [arg]
+      )
+    }
     const n = j.awaitExpression(arg)
     return n
   }


### PR DESCRIPTION
`co` will automatically convert an array of promises yielded to use
`Promise.all`.

e.g. in co, this:

```javascript
const res = yield [a, b, c];
```

is equivalent to

```javascript
const res = Promise.all([a, b, c])
```

Before this commit, `co-to-async` would see:

```javascript
const res = yield [a, b, c]
```

and convert it to

```javascript
const res = await [a, b, c]
```

After this commit, the code is now rewritten as:

```javascript
const res = await Promise.all([a, b, c])
```